### PR TITLE
Added windows instructions for installing make

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,7 @@ npm install -g lerna@3.22.0
 
 To build the project, download the yarn package manager and run:
 >Note: For Windows users, please use git bash as the build currently uses UNIX-based commands. You will also need
-to make sure you have 'make' for windows installed. 
-
-This is installed via chocolatey in Windows Powershell (run as Administrator)
-
-```
-choco install make
-```
+to make sure you have 'make' installed for windows. This is done by running powershell first as Administrator and then installing make with chocolatey: ```choco install make``` 
 
 
 ```


### PR DESCRIPTION
Installing for Windows also has the pre-requisite of installing 'make' for Windows, after installing that I was able to get the build to work. Updated the instructions to reflect that.