### PR TITLE
Fix local test env for integration tests

### DIFF
--- a/packages/overledger-dlt-bitcoin/jest.config.js
+++ b/packages/overledger-dlt-bitcoin/jest.config.js
@@ -119,7 +119,7 @@ module.exports = {
     // runner: "jest-runner",
   
     // The paths to modules that run some code to configure or set up the testing environment before each test
-    // setupFiles: [],
+    setupFiles: ['./test-env.ts'],
   
     // The path to a module that runs some code to configure or set up the testing framework before each test
     // setupTestFrameworkScriptFile: null,

--- a/packages/overledger-dlt-bitcoin/test-env.ts
+++ b/packages/overledger-dlt-bitcoin/test-env.ts
@@ -1,0 +1,3 @@
+// Set env variables for integration testing
+import dotenv from 'dotenv';
+dotenv.config({ path: '../../.env' });

--- a/packages/overledger-dlt-bitcoin/test/dlt-block.test.ts
+++ b/packages/overledger-dlt-bitcoin/test/dlt-block.test.ts
@@ -103,7 +103,7 @@ describe('Integration Tests:', () => {
             expect(overledgerResponse2.data.block.numberOfTransactions).toBeGreaterThanOrEqual(0);
             expect(overledgerResponse2.data.block.transactionIds.length).toBe(overledgerResponse2.data.block.numberOfTransactions);
         }
-    });
+    }, 6000);
 
     test('Standardised latest block and native block align via prep-execute', async () => {
 

--- a/packages/overledger-dlt-ethereum/jest.config.js
+++ b/packages/overledger-dlt-ethereum/jest.config.js
@@ -119,7 +119,7 @@ module.exports = {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: ['./test-env.ts'],
 
   // The path to a module that runs some code to configure or set up the testing framework before each test
   // setupTestFrameworkScriptFile: null,

--- a/packages/overledger-dlt-ethereum/test-env.ts
+++ b/packages/overledger-dlt-ethereum/test-env.ts
@@ -1,0 +1,3 @@
+// Set env variables for integration testing
+import dotenv from 'dotenv';
+dotenv.config({ path: '../../.env' });

--- a/packages/overledger-dlt-ethereum/tests/dlt-block.test.ts
+++ b/packages/overledger-dlt-ethereum/tests/dlt-block.test.ts
@@ -117,7 +117,7 @@ describe('Integration Tests:', () => {
             expect(overledgerResponse2.data.block.numberOfTransactions).toBeGreaterThanOrEqual(0);
             expect(overledgerResponse2.data.block.transactionIds.length).toBe(overledgerResponse2.data.block.numberOfTransactions);
         }
-    });
+    }, 6000);
 
     test('Standardised latest block and native block align via prep-execute', async () => {
 

--- a/packages/overledger-dlt-xrp-ledger/jest.config.js
+++ b/packages/overledger-dlt-xrp-ledger/jest.config.js
@@ -119,7 +119,7 @@ module.exports = {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: ['./test-env.ts'],
 
   // The path to a module that runs some code to configure or set up the testing framework before each test
   // setupTestFrameworkScriptFile: null,

--- a/packages/overledger-dlt-xrp-ledger/test-env.ts
+++ b/packages/overledger-dlt-xrp-ledger/test-env.ts
@@ -1,0 +1,3 @@
+// Set env variables for integration testing
+import dotenv from 'dotenv';
+dotenv.config({ path: '../../.env' });

--- a/packages/overledger-dlt-xrp-ledger/tests/dlt-block.test.ts
+++ b/packages/overledger-dlt-xrp-ledger/tests/dlt-block.test.ts
@@ -9,8 +9,8 @@ const sdkOptions = {
 
 //the changeable links after .../block/
 const latestBlock = "latest";
-const blockByHash = "F1CC4E0859F370D4E9E4DBC5B39398DFDCF90B677F7B96AC9E715589015B55DE";
-const blockByNumber = "22781034";
+const blockByHash = "680C9F655C6782442740A860AC97EC596B5701F17B7D5792B8B5A0C2CC8B3B14";
+const blockByNumber = "24400651";
 
 describe('Integration Tests:', () => {
 

--- a/packages/overledger-dlt-xrp-ledger/tests/dlt-block.test.ts
+++ b/packages/overledger-dlt-xrp-ledger/tests/dlt-block.test.ts
@@ -103,7 +103,7 @@ describe('Integration Tests:', () => {
                 expect(overledgerResponse2.data.block.transactionIds.length).toBe(overledgerResponse2.data.block.numberOfTransactions);
             }
         }
-    });
+    }, 6000);
 
     test('Standardised latest block and native block align via prep-execute', async () => {
 


### PR DESCRIPTION
-Load env variables from root .env file before running integration tests
-Increase timeout for tests to get latest standardised via prep-execute (tests timeout when run locally)
-Update latest block hash and number for XRP Ledger (needs to be done regularly)